### PR TITLE
fix: build correctly for new React and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ iOS AVRoutePickerView for React Native. Provides a native AirPlay button and cor
 npm install react-native-avroutepicker
 ```
 
+On iOS, you'll then need to:
+```sh
+cd ios && pod install
+```
+
 ## Usage
 
 ```js

--- a/react-native-avroutepicker.podspec
+++ b/react-native-avroutepicker.podspec
@@ -13,9 +13,9 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "9.0" }
   s.source       = { :git => "http://.git", :tag => "#{s.version}" }
 
-  
-  s.source_files = "ios/**/*.{h,m,mm}"
-  
 
-  s.dependency "React"
+  s.source_files = "ios/**/*.{h,m,mm}"
+
+
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
Modern React should consume React-Core in order to build correctly (especially with static linking). If you don't make this change, this component won't build, and instead will generate errors about missing `_RCTRegisterModule`.

Also updated the docs to include iOS step required to use the library.

Tested by building locally and running.